### PR TITLE
Replenisher + fee estimation changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,13 @@ run-demo-regtest: packages/fastbtc-node/version.json
 	@docker-compose -f docker-compose-base.yml down --remove-orphans && \
 		docker-compose -f docker-compose-base.yml -f docker-compose-regtest.yml up --build --force-recreate
 
-
-.PHONY: run-demo-regtest-replenisher-tests
-run-demo-regtest-replenisher-tests: packages/fastbtc-node/version.json
-	@export TEST_VERY_SMALL_REPLENISHER_COINS=true && docker-compose -f docker-compose-base.yml down --remove-orphans && \
-		docker-compose -f docker-compose-base.yml -f docker-compose-regtest.yml up --build --force-recreate
+# NOTE: when adding new test cases with env vars, remember to re-export them in docker-compose-regtest.yml
+.PHONY: run-demo-regtest-replenisher-very-small-coins
+run-demo-regtest-replenisher-very-small-coins: packages/fastbtc-node/version.json
+	@export TEST_VERY_SMALL_REPLENISHER_COINS=true && make run-demo-regtest
+.PHONY: run-demo-regtest-replenisher-limits
+run-demo-regtest-replenisher-limits: packages/fastbtc-node/version.json
+	@export TEST_REPLENISHER_LIMITS=true && make run-demo-regtest
 
 .PHONY: show-node-logs
 show-node-logs:

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ test-transfers:
 	@cd packages/fastbtc-contracts && make
 	@integration_test/scripts/test_example_transfer.sh
 
+.PHONY: test-transfers-big-amounts
+test-transfers-big-amounts:
+	@cd packages/fastbtc-contracts && make
+	@integration_test/scripts/test_example_transfer_big_amounts.sh
+
 .PHONY: test-reclaiming
 test-reclaiming:
 	@cd packages/fastbtc-contracts && make

--- a/README.md
+++ b/README.md
@@ -103,7 +103,12 @@ When the multisig balance icreases, it indicates that the multisig was replenish
 multisig.
 The replenisher balance will increase every block.
 
-Hit Ctrl-C to quit it.
+Hit Ctrl-C to quit it (it doesn't quit automatically).
+
+
+### Other integration test cases
+
+#### Reclaiming
 
 There's also another script to test user reclaiming (semi-manually).
 Run it (after starting `make run-demo-regtest`) with:
@@ -112,7 +117,38 @@ Run it (after starting `make run-demo-regtest`) with:
 $ make test-reclaiming
 ```
 
-And observe the output.
+Observe the output, quit with Ctrl-C (it doesn't quit automatically).
+
+#### Very small utxos in replenisher wallet
+
+This test tests the case where the replenisher wallet has very small utxos, which would cause a replenisher transaction
+with 1000+ inputs if no special logic is applied.
+
+```
+# In one tab:
+$ make run-demo-regtest-replenisher-very-small-coins
+# In another tab
+$ make test-transfers
+```
+
+Observe the output, quit with Ctrl-C (it doesn't quit automatically).
+
+#### Replenisher limit edge cases
+
+This test tests the case where the multisig has enough funds for the replenisher not to trigger, but not
+enough funds to send a naively-created TransferBatch, causing the whole system to get stuck.
+
+Unlike the other test cases, this test requires ZSH to run and will quit automatically if it succeeds
+(otherwise it will go on forever).
+
+```
+# In one tab:
+$ make run-demo-regtest-replenisher-limits
+# In another tab
+$ make test-transfers-big-amounts
+```
+
+Observe the output, quit with Ctrl-C if wanted (though it quits automatically on success).
 
 ### Advanced details
 

--- a/docker-compose-regtest.yml
+++ b/docker-compose-regtest.yml
@@ -28,6 +28,7 @@ services:
      - REPLENISHER_ADDRESS=bcrt1qh0j5lcsvezdnrljsfcuetwrg7xen4a6ydmx9pt363e27rph2mntslwp447
      # Extra test vars
      - TEST_VERY_SMALL_REPLENISHER_COINS
+     - TEST_REPLENISHER_LIMITS
 
     ports:
       - 18443:18443

--- a/integration_test/bitcoind-regtest/docker-entrypoint.sh
+++ b/integration_test/bitcoind-regtest/docker-entrypoint.sh
@@ -67,7 +67,7 @@ echo "TEST_VERY_SMALL_REPLENISHER_COINS=$TEST_VERY_SMALL_REPLENISHER_COINS"
 echo "TEST_REPLENISHER_LIMITS=$TEST_REPLENISHER_LIMITS"
 
 # We need a temporary address for both of these cases, because we need to send amounts smaller than the block reward.
-if [ "$TEST_VERY_SMALL_REPLENISHER_COINS" = "true" ] | [ "$TEST_REPLENISHER_LIMITS" = "true" ]
+if [[ "$TEST_VERY_SMALL_REPLENISHER_COINS" = "true" ||  "$TEST_REPLENISHER_LIMITS" = "true" ]]
 then
     echo "Creating temporary wallet address"
     bitcoin-cli createwallet temporary
@@ -83,7 +83,7 @@ else
     TEMPORARY_ADDRESS="temporary_address_not_created_because_not_TEST_VERY_SMALL_REPLENISHER_COINS_or_TEST_REPLENISHER_LIMITS"
 fi
 
-if [ "$TEST_VERY_SMALL_REPLENISHER_COINS" = "true" ]
+if [[ "$TEST_VERY_SMALL_REPLENISHER_COINS" = "true" ]]
 then
     # This is here to test the case where the replenisher wanted to sign a TX with 1000 inputs.
     # This doesn't play well with bitcoin-cli
@@ -102,7 +102,7 @@ then
         done
     done
     echo "Small coins sent"
-elif [ "$TEST_REPLENISHER_LIMITS" = "true" ]
+elif [[ "$TEST_REPLENISHER_LIMITS" = "true" ]]
 then
     echo "Sending 5.5 BTC to the multisig (should be just over the threshold)..."
     bitcoin-cli -rpcwallet=temporary sendtoaddress "$MULTISIG_ADDRESS" 5.5 > /dev/null
@@ -133,12 +133,12 @@ do
     for i in $(bitcoin-cli deriveaddresses "$REPLENISHER_SOURCE_DESCRIPTOR" '[5,100]'|cut -f 2 -d '"'|grep bc)
     do
         echo "Mine a block $(date '+%d/%m/%Y %H:%M:%S') for $i"
-        if [ "$TEST_VERY_SMALL_REPLENISHER_COINS" = "true" ]
+        if [[ "$TEST_VERY_SMALL_REPLENISHER_COINS" = "true" ]]
         then
             # generating to temporary address and then sending to replenisher
             bitcoin-cli -rpcwallet=replenisher generatetoaddress 1 "$TEMPORARY_ADDRESS" > /dev/null
             bitcoin-cli -rpcwallet=temporary sendtoaddress "$i" 0.001 > /dev/null
-        elif [ "$TEST_REPLENISHER_LIMITS" = "true" ]
+        elif [[ "$TEST_REPLENISHER_LIMITS" = "true" ]]
         then
             # Mine to temporary address, send 5 btc to the replenisher
             bitcoin-cli -rpcwallet=replenisher generatetoaddress 1 "$TEMPORARY_ADDRESS" > /dev/null

--- a/integration_test/bitcoind-regtest/docker-entrypoint.sh
+++ b/integration_test/bitcoind-regtest/docker-entrypoint.sh
@@ -43,22 +43,51 @@ echo "Importing desciptor: $ARGS"
 bitcoin-cli -rpcwallet=replenisher importmulti "$ARGS"
 echo "done"
 
-if [ "$TEST_VERY_SMALL_REPLENISHER_COINS" = "true" ]
+##################################################################################################################
+#                                                                                                                #
+#             !!! Time for some explanation of the different test cases in this whole spaghetti !!!              #
+#             =====================================================================================              #
+#                                                                                                                #
+##################################################################################################################
+#
+# - In the default scenario, we mine funds to the replenisher wallet. We then implicitly test that replenishment
+#   works OK and funds get sent to the multisig, and then to the user.
+# - If TEST_VERY_SMALL_REPLENISHER_COINS=true, we test the regression where the number of inputs in a
+#   replenishment transaction was not capped, which resulted in some cases in a tx with >1000 inputs. This caused
+#   the call to bitcoin rpc to take a loooong time, which caused a timeout in ataraxia. And probably such a transaction
+#   would not have passed in the blockchain anyway.
+# - If TEST_REPLENISHER_LIMITS is true, we send some funds to the multisig -- enough that the replenisher doesn't get
+#   triggered (as long as the number matches the one configured in the backend) -- and the rest to the replenisher
+#   wallet. This is meant to test the case where a new TransferBatch cannot be created because the multisig doesn't
+#   have enough funds, but the replenisher doesn't trigger either because the balance is over the threshold.
+#
+# Ugh.
+echo "Test settings:"
+echo "TEST_VERY_SMALL_REPLENISHER_COINS=$TEST_VERY_SMALL_REPLENISHER_COINS"
+echo "TEST_REPLENISHER_LIMITS=$TEST_REPLENISHER_LIMITS"
+
+# We need a temporary address for both of these cases, because we need to send amounts smaller than the block reward.
+if [ "$TEST_VERY_SMALL_REPLENISHER_COINS" = "true" ] | [ "$TEST_REPLENISHER_LIMITS" = "true" ]
 then
-    # This is here to test the case where the replenisher wanted to sign a TX with 1000 inputs.
-    # This doesn't play well with bitcoin-cli
-    echo "TEST_VERY_SMALL_REPLENISHER_COINS = true, seeding the replenisher with multiple coins of 0.001 in size"
     echo "Creating temporary wallet address"
     bitcoin-cli createwallet temporary
     TEMPORARY_ADDRESS=$(bitcoin-cli -rpcwallet=temporary getnewaddress)
     echo "Temporary address: $TEMPORARY_ADDRESS"
-    echo "Generating blocks to the temporary address"
+    echo "Generating 200 blocks to the temporary address"
     bitcoin-cli -rpcwallet=temporary generatetoaddress 200 "$TEMPORARY_ADDRESS" > /dev/null
     echo "Balance of temporary address:"
     bitcoin-cli -rpcwallet=temporary getbalance
     # Set TX fee, very much needed for sending new transactions
     bitcoin-cli -rpcwallet=temporary settxfee 0.00001
+else
+    TEMPORARY_ADDRESS="temporary_address_not_created_because_not_TEST_VERY_SMALL_REPLENISHER_COINS_or_TEST_REPLENISHER_LIMITS"
+fi
 
+if [ "$TEST_VERY_SMALL_REPLENISHER_COINS" = "true" ]
+then
+    # This is here to test the case where the replenisher wanted to sign a TX with 1000 inputs.
+    # This doesn't play well with bitcoin-cli
+    echo "TEST_VERY_SMALL_REPLENISHER_COINS = true, seeding the replenisher with multiple coins of 0.001 in size"
     echo "Sending very small coins to the replenisher address (in 5s)"
     echo "This will take a long time."
     sleep 5
@@ -73,19 +102,22 @@ then
         done
     done
     echo "Small coins sent"
+elif [ "$TEST_REPLENISHER_LIMITS" = "true" ]
+then
+    echo "Sending 5.5 BTC to the multisig (should be just over the threshold)..."
+    bitcoin-cli -rpcwallet=temporary sendtoaddress "$MULTISIG_ADDRESS" 5.5 > /dev/null
 else
-    echo "Generating 101 blocks (sending balance to replenisher wallet, not directly to multisig)..."
+    echo "Generating 101+ blocks (sending balance to replenisher wallet, not directly to multisig)..."
     echo "Init replenisher funds"
     for i in $(bitcoin-cli deriveaddresses "$REPLENISHER_SOURCE_DESCRIPTOR" '[5,10]'|cut -f 2 -d '"'|grep bc)
     do
         echo "Mine a block $(date '+%d/%m/%Y %H:%M:%S') for $i"
-        # Also sending to replenisher here, not multisig
         bitcoin-cli -rpcwallet=replenisher generatetoaddress 1 "$i" > /dev/null
     done
     for i in $(bitcoin-cli deriveaddresses "$REPLENISHER_SOURCE_DESCRIPTOR" '[11,12]'|cut -f 2 -d '"'|grep bc)
     do
         echo "Mine a block $(date '+%d/%m/%Y %H:%M:%S') for $i"
-        # Also sending to replenisher here, not multisig
+        # sending to replenisher here, not multisig
         bitcoin-cli -rpcwallet=replenisher generatetoaddress 50 "$i" > /dev/null
     done
 fi
@@ -106,6 +138,11 @@ do
             # generating to temporary address and then sending to replenisher
             bitcoin-cli -rpcwallet=replenisher generatetoaddress 1 "$TEMPORARY_ADDRESS" > /dev/null
             bitcoin-cli -rpcwallet=temporary sendtoaddress "$i" 0.001 > /dev/null
+        elif [ "$TEST_REPLENISHER_LIMITS" = "true" ]
+        then
+            # Mine to temporary address, send 5 btc to the replenisher
+            bitcoin-cli -rpcwallet=replenisher generatetoaddress 1 "$TEMPORARY_ADDRESS" > /dev/null
+            bitcoin-cli -rpcwallet=temporary sendtoaddress "$i" 5.0 > /dev/null
         else
             # sending to replenisher here, not multisig
             bitcoin-cli -rpcwallet=replenisher generatetoaddress 1 "$i" > /dev/null

--- a/integration_test/scripts/test_example_transfer_big_amounts.sh
+++ b/integration_test/scripts/test_example_transfer_big_amounts.sh
@@ -19,7 +19,6 @@ echo "Replenisher balance before:  $($THIS_DIR/bitcoin-cli.sh -rpcwallet=repleni
 npx hardhat --network integration-test free-money 0xB3b77A8Bc6b6fD93D591C0F34f202eC02e9af2e8 $TOTAL_TRANSFERRED
 echo "Setting max limit to $SINGLE_TRANSFER_AMOUNT BTC"
 npx hardhat --network integration-test set-limits --max-btc $SINGLE_TRANSFER_AMOUNT
-sleep 1
 npx hardhat --network integration-test transfer-rbtc-to-btc 0xc1daad254b7005eca65780d47213d3de15bd92fcce83777487c5082c6d27600a bcrt1qq8zjw66qrgmynrq3gqdx79n7fcchtaudq4rrf0 $SINGLE_TRANSFER_AMOUNT --bridge-address 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9 --repeat $NUM_TRANSFERS
 
 echo "$NUM_TRANSFERS transfers sent, totaling $TOTAL_TRANSFERRED BTC. They should be visible in a couple of minutes"

--- a/integration_test/scripts/test_example_transfer_big_amounts.sh
+++ b/integration_test/scripts/test_example_transfer_big_amounts.sh
@@ -1,0 +1,36 @@
+#!/bin/zsh
+# bash `let` fails with decimals so let's just use zsh. or maybe we should rewrite this in python
+set -e
+cd "$(dirname "$0")"
+THIS_DIR=$(pwd)
+cd ../../packages/fastbtc-contracts
+USER_INITIAL_BALANCE="$($THIS_DIR/bitcoin-cli.sh -rpcwallet=user getbalance)"
+# percentage fee 0.01 %, fixed fee 500 sat
+PERCENTAGE_FEE=0.0001
+FIXED_FEE=0.000005
+SINGLE_TRANSFER_AMOUNT=3
+NUM_TRANSFERS=5
+let 'TOTAL_TRANSFERRED=SINGLE_TRANSFER_AMOUNT*NUM_TRANSFERS'
+let 'USER_EXPECTED_FINAL_BALANCE=(USER_INITIAL_BALANCE+(TOTAL_TRANSFERRED*(1.0-PERCENTAGE_FEE))-(NUM_TRANSFERS*FIXED_FEE))'
+echo "User balance before:         $USER_INITIAL_BALANCE BTC"
+echo "User expected balance after: $USER_EXPECTED_FINAL_BALANCE BTC"
+echo "Multisig balance before:     $($THIS_DIR/bitcoin-cli.sh -rpcwallet=multisig getbalance) BTC"
+echo "Replenisher balance before:  $($THIS_DIR/bitcoin-cli.sh -rpcwallet=replenisher getbalance) BTC"
+npx hardhat --network integration-test free-money 0xB3b77A8Bc6b6fD93D591C0F34f202eC02e9af2e8 $TOTAL_TRANSFERRED
+echo "Setting max limit to $SINGLE_TRANSFER_AMOUNT BTC"
+npx hardhat --network integration-test set-limits --max-btc $SINGLE_TRANSFER_AMOUNT
+sleep 1
+npx hardhat --network integration-test transfer-rbtc-to-btc 0xc1daad254b7005eca65780d47213d3de15bd92fcce83777487c5082c6d27600a bcrt1qq8zjw66qrgmynrq3gqdx79n7fcchtaudq4rrf0 $SINGLE_TRANSFER_AMOUNT --bridge-address 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9 --repeat $NUM_TRANSFERS
+
+echo "$NUM_TRANSFERS transfers sent, totaling $TOTAL_TRANSFERRED BTC. They should be visible in a couple of minutes"
+echo "Polling balances, Ctrl-C to exit"
+while true ; do
+    USER_BALANCE="$($THIS_DIR/bitcoin-cli.sh -rpcwallet=user getbalance)"
+    BALANCE_MATCHES=$(echo "$USER_BALANCE == $USER_EXPECTED_FINAL_BALANCE" | bc)
+    echo "User: $USER_BALANCE  Multisig: $($THIS_DIR/bitcoin-cli.sh -rpcwallet=multisig getbalance)  Replenisher: $($THIS_DIR/bitcoin-cli.sh -rpcwallet=replenisher getbalance)"
+    if [[ $BALANCE_MATCHES == 1 ]] ; then
+        echo "User balance is the expected final balance -- test success"
+        exit 0
+    fi
+    sleep 10
+done

--- a/packages/fastbtc-contracts/hardhat.config.ts
+++ b/packages/fastbtc-contracts/hardhat.config.ts
@@ -35,7 +35,8 @@ task("accounts", "Prints the list of accounts", async (args, hre) => {
     const accounts = await hre.ethers.getSigners();
 
     for (const account of accounts) {
-        console.log(account.address);
+        const balance = await hre.ethers.provider.getBalance(account.address);
+        console.log(account.address, "balance:", hre.ethers.utils.formatEther(balance));
     }
 });
 

--- a/packages/fastbtc-contracts/hardhat.config.ts
+++ b/packages/fastbtc-contracts/hardhat.config.ts
@@ -96,12 +96,13 @@ task("free-money", "Sends free money to address")
 
         const accounts = await hre.ethers.getSigners();
 
-        const receipt = await accounts[0].sendTransaction({
+        const tx = await accounts[0].sendTransaction({
             to: address,
             value: rbtcAmountWei,
         })
 
-        console.log('tx hash:', receipt.hash);
+        console.log('tx hash:', tx.hash, 'waiting for tx...');
+        await tx.wait();
     });
 
 task("transfer-rbtc-to-btc", "Transfers RBTC to BTC")
@@ -139,6 +140,7 @@ task("transfer-rbtc-to-btc", "Transfers RBTC to BTC")
                 {value: rbtcAmountWei}
             );
             console.log('tx hash:', receipt.hash);
+            // NOTE: don't wait here, we want to possibly get these to the same block
         }
     });
 
@@ -356,8 +358,9 @@ task("set-limits", "Set min/max transfer limits")
                 console.log("Min amount unchanged");
             } else {
                 console.log('Setting minimum to: %s BTC (%s sat)', minBtc, newMinSatoshi.toString());
-                const receipt = await contract.setMinTransferSatoshi(newMinSatoshi);
-                console.log('tx hash:', receipt.hash);
+                const tx = await contract.setMinTransferSatoshi(newMinSatoshi);
+                console.log('tx hash:', tx.hash, 'waiting for tx...');
+                await tx.wait();
             }
         }
 
@@ -367,8 +370,9 @@ task("set-limits", "Set min/max transfer limits")
                 console.log("Max amount unchanged");
             } else {
                 console.log('Setting maximum to: %s BTC (%s sat)', maxBtc, newMaxSatoshi.toString());
-                const receipt = await contract.setMaxTransferSatoshi(newMaxSatoshi);
-                console.log('tx hash:', receipt.hash);
+                const tx = await contract.setMaxTransferSatoshi(newMaxSatoshi);
+                console.log('tx hash:', tx.hash, 'waiting for tx...');
+                await tx.wait();
             }
         }
     });

--- a/packages/fastbtc-node/src/btc/multisig.ts
+++ b/packages/fastbtc-node/src/btc/multisig.ts
@@ -237,7 +237,7 @@ export class BitcoinMultisig {
         maxInputs: number|undefined = undefined,
     ): Promise<PartiallySignedBitcoinTransaction> {
         // TODO: this method is a mess. Too many ifs because of the replenisher stuff.
-        const estimateRawFeeOutput = await this.nodeWrapper.call('estimaterawfee', [2]);
+        const estimateRawFeeOutput = await this.nodeWrapper.call('estimaterawfee', [1]);
         let feeBtcPerKB = estimateRawFeeOutput.short.feerate;
         if (typeof feeBtcPerKB !== 'number') {
             // estimateRawFee doesn't work on regtest
@@ -247,7 +247,7 @@ export class BitcoinMultisig {
             else {
                 const response = JSON.stringify(estimateRawFeeOutput);
                 throw new Error(
-                    `Unable to deduce gas fee, got ${response} for response from estimaterawfee 2 from node`
+                    `Unable to deduce gas fee, got ${response} for response from estimaterawfee 1 from node`
                 );
             }
         }

--- a/packages/fastbtc-node/src/btc/multisig.ts
+++ b/packages/fastbtc-node/src/btc/multisig.ts
@@ -360,7 +360,7 @@ export class BitcoinMultisig {
 
         const transferSumIncludingFee = amountSatoshi.add(fee);
         if (totalSum.lt(transferSumIncludingFee)) {
-            if (maxInputs && totalInputCount >= maxInputs && response.length > maxInputs) {
+            if (maxInputs && noChange && !totalSum.isZero()) {
                 this.logger.warning(
                     `Number of inputs is capped at ${maxInputs} -- can only send ` +
                     `${totalSum.toString()} satoshi out of ${transferSumIncludingFee.toString()} satoshi wanted. ` +

--- a/packages/fastbtc-node/src/btc/multisig.ts
+++ b/packages/fastbtc-node/src/btc/multisig.ts
@@ -246,7 +246,9 @@ export class BitcoinMultisig {
             }
             else {
                 const response = JSON.stringify(estimateRawFeeOutput);
-                throw new Error(`Unable to deduce gas fee, got ${response} for response from estimaterawfee 2 from node`);
+                throw new Error(
+                    `Unable to deduce gas fee, got ${response} for response from estimaterawfee 2 from node`
+                );
             }
         }
 

--- a/packages/fastbtc-node/src/config.ts
+++ b/packages/fastbtc-node/src/config.ts
@@ -201,25 +201,6 @@ function getReplenisherConfig(env: Record<string, string>): ReplenisherConfig | 
         }
     }
 
-    ret.replenishThreshold = parseConfigFloat(env, 'FASTBTC_REPLENISHER_THRESHOLD');
-    ret.replenishMinAmount = parseConfigFloat(env, 'FASTBTC_REPLENISHER_MIN_AMOUNT');
-    ret.replenishPeriod = parseConfigNumber(
-        env,
-        'FASTBTC_REPLENISHER_PERIOD',
-        {
-            allowZero: false,
-            parser: parseInt,
-        }
-    );
-    ret.maxReplenishmentsDuringPeriod = parseConfigNumber(
-        env,
-        'FASTBTC_REPLENISHER_MAX_REPLENISHMENTS_DURING_PERIOD',
-        {
-            allowZero: true,
-            parser: parseInt,
-        }
-    );
-
     if (missingKeys.length > 0) {
         if (givenKeys.length > 0) {
             console.warn(

--- a/packages/fastbtc-node/src/replenisher/config.ts
+++ b/packages/fastbtc-node/src/replenisher/config.ts
@@ -11,8 +11,4 @@ export interface ReplenisherConfig {
     keyDerivationPath: string;
     numRequiredSigners: number;
     secrets: () => ReplenisherSecrets;
-    replenishThreshold?: number;
-    replenishMinAmount?: number;
-    maxReplenishmentsDuringPeriod?: number;
-    replenishPeriod?: number;
 }

--- a/packages/fastbtc-node/src/replenisher/replenisher.ts
+++ b/packages/fastbtc-node/src/replenisher/replenisher.ts
@@ -48,12 +48,6 @@ export class ActualBitcoinReplenisher implements BitcoinReplenisher {
         this.numRequiredSigners = config.numRequiredSigners;
         // It's possible that this node is not a replenisher though it can be the initiator
         this.isReplenisher = !!config.secrets().masterPrivateKey;
-        if (config.maxReplenishmentsDuringPeriod !== undefined) {
-            this.maxReplenishmentsDuringPeriod = config.maxReplenishmentsDuringPeriod;
-        }
-        if (config.replenishPeriod !== undefined) {
-            this.replenishPeriod = config.replenishPeriod;
-        }
         network.onMessage(this.onMessage);
     }
 

--- a/packages/fastbtc-node/src/replenisher/replenisher.ts
+++ b/packages/fastbtc-node/src/replenisher/replenisher.ts
@@ -33,7 +33,7 @@ export class ActualBitcoinReplenisher implements BitcoinReplenisher {
     private isReplenisher: boolean;
 
     // Limit replenishments to N per period as a security measure
-    private readonly maxReplenishmentsDuringPeriod: number = 2;
+    private readonly maxReplenishmentsDuringPeriod: number = 3;
     private readonly replenishPeriod: number = 24 * 60 * 60 * 1000; // 1 day
     // Keeping all replenishment periods in a record will in theory leak memory,
     // but replenishments should be rare enough for this not to matter

--- a/packages/fastbtc-node/src/replenisher/replenishermultisig.ts
+++ b/packages/fastbtc-node/src/replenisher/replenishermultisig.ts
@@ -12,7 +12,7 @@ export class ReplenisherMultisig {
     private replenisherMultisig: BitcoinMultisig;
     private numRequiredSigners;
     private replenishThreshold = 5.0;
-    private replenishMinAmount = 1.0;
+    private replenishMinAmount = 5.0;
     private maxReplenishTxInputs = 100;
     private isReplenisher: boolean; // is this node a replenisher
     private network: Network;

--- a/packages/fastbtc-node/src/replenisher/replenishermultisig.ts
+++ b/packages/fastbtc-node/src/replenisher/replenishermultisig.ts
@@ -24,12 +24,6 @@ export class ReplenisherMultisig {
         private statsd: StatsD,
     ) {
         this.numRequiredSigners = config.numRequiredSigners;
-        if (config.replenishThreshold) {
-            this.replenishThreshold = config.replenishThreshold;
-        }
-        if (config.replenishMinAmount) {
-            this.replenishMinAmount = config.replenishMinAmount;
-        }
 
         this.isReplenisher = !!config.secrets().masterPrivateKey;
         this.network = networks[config.btcNetwork === 'mainnet' ? 'bitcoin' : config.btcNetwork];

--- a/packages/fastbtc-node/src/replenisher/replenishermultisig.ts
+++ b/packages/fastbtc-node/src/replenisher/replenishermultisig.ts
@@ -5,14 +5,15 @@ import {BigNumber} from 'ethers';
 import {Network, networks, Psbt} from 'bitcoinjs-lib';
 import {ReplenisherConfig} from './config';
 import {StatsD} from 'hot-shots';
+import {MAX_BTC_IN_BATCH} from '../core/transfers';
 
 export class ReplenisherMultisig {
     private logger = new Logger('replenisher');
 
     private replenisherMultisig: BitcoinMultisig;
     private numRequiredSigners;
-    private replenishThreshold = 5.0;
-    private replenishMinAmount = 5.0;
+    private replenishThreshold = MAX_BTC_IN_BATCH;
+    private replenishMinAmount = MAX_BTC_IN_BATCH;
     private maxReplenishTxInputs = 100;
     private isReplenisher: boolean; // is this node a replenisher
     private network: Network;


### PR DESCRIPTION
- Estimate fee so that **BTC transactions are mined in 1 block** (was 2)
- Raise replenisher **min amount to 5.0 BTC**, **threshold to 5.0** and max replenishments to **3 times a day**
- **Cap total BTC in TransferBatch** to 5.0 BTC
- Allow all **non-zero replenishment transactions** (previously it failed unless min amount was met, or max inputs were reached).
- Try to handle the case where a **UTXO was no longer unused** and therefore the whole replenisher process hung until restart.
- Remove unused replenisher config that only served to confuse. Just hardcode all the things
- Minor changes to hardhat tasks